### PR TITLE
Ajax action name should be unique

### DIFF
--- a/options.php
+++ b/options.php
@@ -53,7 +53,7 @@ add_action( 'admin_init', function() {
   register_setting( 'messenger-integration-plugin-settings', 'fbmcc_generatedCode' );
 });
 
-add_action( 'wp_ajax_update_options', 'fbmcc_update_options');
+add_action( 'wp_ajax_fbmcc_update_options', 'fbmcc_update_options');
 
 function fbmcc_update_options() {
   check_ajax_referer( 'update_fmcc_code' );

--- a/script.js
+++ b/script.js
@@ -30,7 +30,7 @@ function fbmcc_setupCustomerChat() {
     if (e.originalEvent.origin === FACEBOOK_URL) {
       $data_json = JSON.parse(e.originalEvent.data);
       var data = {
-        'action' : 'update_options',
+        'action' : 'fbmcc_update_options',
         'pageID' : fbmcc_sanitizeNumbersOnly($data_json["pageID"]),
         'locale' : fbmcc_sanitizeLocale($data_json["locale"]),
         'themeColor' : fbmcc_sanitizeHexColor($data_json["themeColorCode"]),


### PR DESCRIPTION
The plugin uses [ajax action](https://developer.wordpress.org/reference/hooks/wp_ajax_action/) **update_options**. Ajax action name should be more unique because if two plugins use the same ajax action name, they will conflict. Quite some plugins in WordPress repository use ajax action update_options.  