### PR TITLE
Unique enqueue handle to prevent conflicts with other plugins & themes.

### DIFF
--- a/options.php
+++ b/options.php
@@ -64,7 +64,7 @@ function fbmcc_update_options() {
 
 function fbmcc_add_styles() {
   wp_enqueue_style(
-    'admin-styles',
+    'wordpress-messenger-chat-plugin-admin-styles',
     plugins_url( '/settings.css', __FILE__ ),
     false,
     '1.0',


### PR DESCRIPTION
WordPress enqueue handles should be unique to prevent conflicts with other plugins and themes.

The handle "admin-styles" is too generic and creates conflicts. The handle "wordpress-messenger-chat-plugin-admin-styles" is far less likely to collide with anything.